### PR TITLE
made some changes to make detecting tapwater active easier. might also make the gas calculation possible?

### DIFF
--- a/src/boiler.ino
+++ b/src/boiler.ino
@@ -238,6 +238,19 @@ void _renderIntValue(const char * prefix, const char * postfix, uint8_t value) {
     myDebug("\n");
 }
 
+// takes an int value at prints it to debug log
+void _renderIntfractionalValue(const char * prefix, const char * postfix, uint8_t value, uint8_t decimals) {
+    myDebug("  %s: ", prefix);
+    char s[20];
+    myDebug("%s.", _int_to_char(s, value/(decimals*10)));
+    myDebug("%s", _int_to_char(s, value%(decimals*10)));
+    if (postfix != NULL) {
+        myDebug(" %s", postfix);
+    }
+
+    myDebug("\n");
+}
+
 // takes a bool value at prints it to debug log
 void _renderBoolValue(const char * prefix, uint8_t value) {
     myDebug("  %s: ", prefix);
@@ -291,6 +304,7 @@ void showInfo() {
 
     // UBAMonitorWWMessage
     _renderFloatValue("Warm Water current temperature", "C", EMS_Boiler.wWCurTmp);
+    _renderIntfractionalValue("Warm Water current tapwater flow", "l/min", EMS_Boiler.wWCurFlow, 1);
     _renderIntValue("Warm Water # starts", "times", EMS_Boiler.wWStarts);
     myDebug("  Warm Water active time: %d days %d hours %d minutes\n",
             EMS_Boiler.wWWorkM / 1440,
@@ -311,6 +325,7 @@ void showInfo() {
     _renderIntValue("Burner current power", "%", EMS_Boiler.curBurnPow);
     _renderFloatValue("Flame current", "uA", EMS_Boiler.flameCurr);
     _renderFloatValue("System pressure", "bar", EMS_Boiler.sysPress);
+    myDebug("  Current System Service Code: %c%c \n", EMS_Boiler.serviceCodeChar1, EMS_Boiler.serviceCodeChar2);
 
     // UBAMonitorSlow
     _renderFloatValue("Outside temperature", "C", EMS_Boiler.extTemp);
@@ -382,6 +397,9 @@ void publishValues(bool force) {
     rootBoiler["wWSelTemp"]   = _int_to_char(s, EMS_Boiler.wWSelTemp);
     rootBoiler["wWActivated"] = _bool_to_char(s, EMS_Boiler.wWActivated);
     rootBoiler["wWCurTmp"]    = _float_to_char(s, EMS_Boiler.wWCurTmp);
+    
+    sprintf(s, "%i.%i", EMS_Boiler.wWCurFlow/10, EMS_Boiler.wWCurFlow%10);
+    rootBoiler["wWCurFlow"]   = s;
     rootBoiler["wWHeat"]      = _bool_to_char(s, EMS_Boiler.wWHeat);
     rootBoiler["curFlowTemp"] = _float_to_char(s, EMS_Boiler.curFlowTemp);
     rootBoiler["retTemp"]     = _float_to_char(s, EMS_Boiler.retTemp);
@@ -395,6 +413,8 @@ void publishValues(bool force) {
     rootBoiler["sysPress"]    = _float_to_char(s, EMS_Boiler.sysPress);
     rootBoiler["boilTemp"]    = _float_to_char(s, EMS_Boiler.boilTemp);
     rootBoiler["pumpMod"]     = _int_to_char(s, EMS_Boiler.pumpMod);
+    sprintf(s, "%c%c", EMS_Boiler.serviceCodeChar1, EMS_Boiler.serviceCodeChar2);
+    rootBoiler["ServiceCode"] = s;
 
     size_t len = rootBoiler.measureLength();
     rootBoiler.printTo(data, len + 1); // form the json string

--- a/src/boiler.ino
+++ b/src/boiler.ino
@@ -299,6 +299,7 @@ void showInfo() {
     // UBAParameterWW
     _renderBoolValue("Warm Water activated", EMS_Boiler.wWActivated);
     _renderBoolValue("Warm Water circulation pump available", EMS_Boiler.wWCircPump);
+    myDebug("  Warm Water is set to %s\n", (EMS_Boiler.wWComfort ? "Comfort" : "ECO"));
     _renderIntValue("Warm Water selected temperature", "C", EMS_Boiler.wWSelTemp);
     _renderIntValue("Warm Water desired temperature", "C", EMS_Boiler.wWDesiredTemp);
 
@@ -396,6 +397,8 @@ void publishValues(bool force) {
 
     rootBoiler["wWSelTemp"]   = _int_to_char(s, EMS_Boiler.wWSelTemp);
     rootBoiler["wWActivated"] = _bool_to_char(s, EMS_Boiler.wWActivated);
+    sprintf(s, "%s",  (EMS_Boiler.wWComfort ? "Comfort" : "ECO"));
+    rootBoiler["wWComfort"]   = s;
     rootBoiler["wWCurTmp"]    = _float_to_char(s, EMS_Boiler.wWCurTmp);
     
     sprintf(s, "%i.%i", EMS_Boiler.wWCurFlow/10, EMS_Boiler.wWCurFlow%10);

--- a/src/ems.h
+++ b/src/ems.h
@@ -162,19 +162,21 @@ typedef struct {           // UBAParameterWW
     uint8_t wWDesiredTemp; // Warm Water desired temperature
 
     // UBAMonitorFast
-    uint8_t selFlowTemp; // Selected flow temperature
-    float   curFlowTemp; // Current flow temperature
-    float   retTemp;     // Return temperature
-    uint8_t burnGas;     // Gas on/off
-    uint8_t fanWork;     // Fan on/off
-    uint8_t ignWork;     // Ignition on/off
-    uint8_t heatPmp;     // Circulating pump on/off
-    uint8_t wWHeat;      // 3-way valve on WW
-    uint8_t wWCirc;      // Circulation on/off
-    uint8_t selBurnPow;  // Burner max power
-    uint8_t curBurnPow;  // Burner current power
-    float   flameCurr;   // Flame current in micro amps
-    float   sysPress;    // System pressure
+    uint8_t selFlowTemp;      // Selected flow temperature
+    float   curFlowTemp;      // Current flow temperature
+    float   retTemp;          // Return temperature
+    uint8_t burnGas;          // Gas on/off
+    uint8_t fanWork;          // Fan on/off
+    uint8_t ignWork;          // Ignition on/off
+    uint8_t heatPmp;          // Circulating pump on/off
+    uint8_t wWHeat;           // 3-way valve on WW
+    uint8_t wWCirc;           // Circulation on/off
+    uint8_t selBurnPow;       // Burner max power
+    uint8_t curBurnPow;       // Burner current power
+    float   flameCurr;        // Flame current in micro amps
+    float   sysPress;         // System pressure
+    uint8_t serviceCodeChar1; // First  Character in status/service code
+    uint8_t serviceCodeChar2; // Second Character in status/service code
 
     // UBAMonitorSlow
     float    extTemp;     // Outside temperature
@@ -189,6 +191,7 @@ typedef struct {           // UBAParameterWW
     uint32_t wWStarts;  // Warm Water # starts
     uint32_t wWWorkM;   // Warm Water # minutes
     uint8_t  wWOneTime; // Warm Water one time function on/off
+    uint8_t  wWCurFlow; // Warm Water current flow in l/min
 
     // calculated values
     uint8_t tapwaterActive; // Hot tap water is on/off

--- a/src/ems.h
+++ b/src/ems.h
@@ -44,6 +44,10 @@
 #define EMS_OFFSET_UBAParameterWW_wwtemp 2      // WW Temperature
 #define EMS_OFFSET_UBAParameterWW_wwactivated 1 // WW Activated
 
+#define EMS_OFFSET_UBAParameterWW_wwComfort 9   // WW is in comfort or eco mode
+#define EMS_VALUE_UBAParameterWW_wwComfort_Comfort 0x00   // the value for comfort
+#define EMS_VALUE_UBAParameterWW_wwComfort_Eco 0xD8       // the value for eco
+
 /* 
  * Thermostat...
  */
@@ -160,6 +164,7 @@ typedef struct {           // UBAParameterWW
     uint8_t wWSelTemp;     // Warm Water selected temperature
     uint8_t wWCircPump;    // Warm Water circulation pump Available
     uint8_t wWDesiredTemp; // Warm Water desired temperature
+    uint8_t wWComfort;     // Warm water comfort or ECO mode
 
     // UBAMonitorFast
     uint8_t selFlowTemp;      // Selected flow temperature
@@ -253,6 +258,7 @@ void ems_setThermostatTemp(float temp);
 void ems_setThermostatMode(uint8_t mode);
 void ems_setWarmWaterTemp(uint8_t temperature);
 void ems_setWarmWaterActivated(bool activated);
+void ems_setWarmWaterModeComfort(bool comfort);
 void ems_setWarmTapWaterActivated(bool activated);
 void ems_setExperimental(uint8_t value);
 void ems_setPoll(bool b);

--- a/src/my_config.h
+++ b/src/my_config.h
@@ -34,6 +34,9 @@
 #define EMS_BOILER_BURNPOWER_TAPWATER 100
 #define EMS_BOILER_SELFLOWTEMP_HEATING 70
 
+//define maximum settable tapwater temperature, not every installation supports 90 degrees
+#define EMS_BOILER_TAPWATER_TEMPERATURE_MAX 60
+
 // if using the shower timer, change these settings
 #define SHOWER_PAUSE_TIME 15000     // in ms. 15 seconds, max time if water is switched off & on during a shower
 #define SHOWER_MIN_DURATION 120000  // in ms. 2 minutes, before recognizing its a shower


### PR DESCRIPTION
added EMS_BOILER_TAPWATER_TEMPERATURE_MAX to my_config.h, not all boilers support 90 degrees max

changed tapwater detection mechanism:
  - added EMS_BOILER.wWCurFlow to be read from 0x34 messages, this gives the current amount of tapwater flowing in dl/min
  - added wWCurFlow to mqtt message
  - added wWCurFlow to telnet statistics
  changed detection from: selBurnPow and selFlowTemp to wWCurFlow
added the current servicecode as seen on thermostat and boieler display to telnet statistics and mqtt message